### PR TITLE
Possible fix for #174 and #175 plus minor improvements to TypeSelectionPopupWindow

### DIFF
--- a/Assets/FullInspector2/Core/fiSettings.cs
+++ b/Assets/FullInspector2/Core/fiSettings.cs
@@ -224,6 +224,13 @@ namespace FullInspector {
         /// in the type selection. Also used in the ScriptableObjects inspector.
         /// </summary>
         public static List<string> TypeSelectionDefaultFilters;
+        
+        /// <summary>
+        /// If this is set, any type that matches any list element
+        /// will never be shown in the type selection.
+        /// Also used in the ScriptableObjects inspector.
+        /// </summary>
+        public static List<string> TypeSelectionBlacklist;
 
         /// <summary>
         /// This is automatically configured based on RootDirectory. This has a

--- a/Assets/FullInspector2/Core/fiSettings.cs
+++ b/Assets/FullInspector2/Core/fiSettings.cs
@@ -218,6 +218,12 @@ namespace FullInspector {
         /// has a trailing slash.
         /// </summary>
         public static string RootDirectory = "Assets/FullInspector2/";
+        
+        /// <summary>
+        /// If this is set, the list will be use to limit what types are shown 
+        /// in the type selection. Also used in the ScriptableObjects inspector.
+        /// </summary>
+        public static List<string> TypeSelectionDefaultFilters;
 
         /// <summary>
         /// This is automatically configured based on RootDirectory. This has a

--- a/Assets/FullInspector2/Modules/Common/Editor/TypeSelectionPopupWindow.cs
+++ b/Assets/FullInspector2/Modules/Common/Editor/TypeSelectionPopupWindow.cs
@@ -51,7 +51,7 @@ namespace FullInspector.Modules {
                     var inspected = InspectedType.Get(type);
                     if (inspected.IsCollection == false) {
                         var shouldAdd = blackList == null ||
-                                        (blackList != null) && !blackList.Any(t => type.FullName.ToUpper().Contains(t.ToUpper()));
+                                        !blackList.Any(t => type.FullName.ToUpper().Contains(t.ToUpper()));
 
                         if (shouldAdd) {
                             _allTypesWithStatics.Add(type);


### PR DESCRIPTION
This might be enough to fix both #174 and #175.

By default, if the user has set the `TypeSelectionDefaultFilters` using the `fiSettings` system, a toggle will show (enabled by default) that filters the results on both the StaticsInspectorWindow and any TypeSelectionPopupWindow.

If the `TypeSelectionDefaultFilters` is not set, the toggle will not be shown.

Since I was already playing with this, I went and added two little extra features

* a little counter for how many types are in display in the TypeSelectionPopupWindow. It lags behind to display the first time around, but should be simple to fix later if necessary

* an (optional) global blacklist for the TypeSelectionPopupWindow so the user can easily hide all those crazy internal types from third party libraries. Again, this will only be used if set.