### PR TITLE
fix FI exception when acessing destroyed object

### DIFF
--- a/Assets/FullInspector2/Core/fiLateBindings.cs
+++ b/Assets/FullInspector2/Core/fiLateBindings.cs
@@ -144,7 +144,9 @@ namespace FullInspector.Internal {
         public static class EditorUtility {
             public static void SetDirty(UnityObject unityObject) {
                 if (VerifyBinding("EditorUtility.SetDirty", _Bindings._EditorUtility_SetDirty)) {
-                    _Bindings._EditorUtility_SetDirty(unityObject);
+                    if (unityObject != null) {
+                        _Bindings._EditorUtility_SetDirty(unityObject);
+                    }
                 }
             }
 


### PR DESCRIPTION
When destroying an object with `DestroyImmediate` programmatically, an exception will occur because FI will try to access the destroyed object. This PR fixes that.

There are probably other spots in the LateBindings where a null check could be useful, but I haven't reached any other yet.


An example where this will occur is in a toolkit editor with something like this

```C#
new tk.Button(
    new fiGUIContent("Remove"),
    (o, c) => DestroyImmediate(this)
)
```