### PR TITLE
alternative fix for #185 without ifdefs

### DIFF
--- a/Assets/FullInspector2/Core/fiLateBindings.cs
+++ b/Assets/FullInspector2/Core/fiLateBindings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
 using UnityObject = UnityEngine.Object;
@@ -21,6 +22,9 @@ namespace FullInspector.Internal {
             public static Action<Action> _EditorApplication_InvokeOnEditorThread;
             public static Action<Action> _EditorApplication_AddUpdateAction;
             public static Action<Action> _EditorApplication_RemUpdateAction;
+            public static List<Action> _EditorApplication_Callbacks;
+            public static List<Action> _EditorApplication_CallbacksToBeAdded;
+            public static List<Action> _EditorApplication_CallbacksToBeRemoved;
             public static Func<double> _EditorApplication_timeSinceStartup;
 
             public static Func<string, string, string> _EditorPrefs_GetString;


### PR DESCRIPTION
This is an alternative PR for #187 

It uses lists and adds a single callback to the EditorApplication.update delegate.
It is based on a solution I use internally and the comment @jacobdufault made on #187.

I quickly tested and it seems to work, but would appreciate a review before merging.

---

I'm amazed I hadn't noticed this issue until @hymerman mentioned. I guess I just crash Unity so much that I rarely go long enough for it to became apparent.

Today, I just left Unity sit open and active for a few hours (the computer didn't sleep because Windows) and when I came back I though I had a memory leak on my mesh generation. Turns out it was this issue. It was allocating over a megabyte per frame!

Really glad @hymerman brought this up!


