### PR TITLE
tkControl performance improvements

### DIFF
--- a/Assets/FullInspector2/Core/Utility/InspectedMemberFilters.cs
+++ b/Assets/FullInspector2/Core/Utility/InspectedMemberFilters.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using FullInspector.Internal;
 using FullSerializer.Internal;
@@ -65,6 +66,19 @@ namespace FullInspector {
             }
         }
         public static IInspectedMemberFilter ButtonMembers = new ButtonMembersFilter();
+
+        public class TkControlMembersFilter: IInspectedMemberFilter {
+
+            public bool IsInterested(InspectedProperty property) {
+                return (typeof(IEnumerable<tkIControl>).IsAssignableFrom(property.StorageType) ||
+                        typeof(tkIControl).IsAssignableFrom(property.StorageType));
+            }
+
+            public bool IsInterested(InspectedMethod method) {
+                return false;
+            }
+        }
+        public static TkControlMembersFilter TkControlMembers = new TkControlMembersFilter();
 
         /// <summary>
         /// Returns true if the given property should be displayed in the


### PR DESCRIPTION
Improved tkControl perfomance by making it use `InspectedType.Get(type).GetMembers()` (cached) instead of `type.GetDeclaredMembers()`.
Also create a filter for the types that tkControls are interested (`IEnumerable<tkIControl>` and `tkIControl`).

This has a dramatic impact thanks to caching.

Without this, having a collection of types that have tkControls could take a long time to show for the first time. Plus, creating a new inspector for the same type would be just as slow as the first one (no reuse).

With this, creating the first one is already fast, but the next ones are even faster.