### PR TITLE
Add Color32 CustomPropertyEditor.

### DIFF
--- a/Assets/FullInspector2/Modules/Common/Editor/CommonPropertyEditors.cs
+++ b/Assets/FullInspector2/Modules/Common/Editor/CommonPropertyEditors.cs
@@ -236,6 +236,17 @@ namespace FullInspector.Modules {
         }
     }
 
+    [CustomPropertyEditor(typeof(Color32))]
+    public class Color32PropertyEditor : PropertyEditor<Color32> {
+        public override Color32 Edit(Rect region, GUIContent label, Color32 element, fiGraphMetadata metadata) {
+            return EditorGUI.ColorField(region, label, element);
+        }
+
+        public override float GetElementHeight(GUIContent label, Color32 element, fiGraphMetadata metadata) {
+            return EditorStyles.colorField.CalcHeight(label, 1000);
+        }
+    }
+
     [CustomPropertyEditor(typeof(AnimationCurve))]
     public class AnimationCurvePropertyEditor : PropertyEditor<AnimationCurve> {
         public override AnimationCurve Edit(Rect region, GUIContent label, AnimationCurve element, fiGraphMetadata metadata) {


### PR DESCRIPTION
Color32 properties were being drawn as Vector4 in the inspector. Explicitly adding a Color32 CustomPropertyEditor resolves this.